### PR TITLE
Closes #9 -- Magic Hydration by Property

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,3 +3,7 @@ parameters:
   paths:
     - src
     - tests
+  ignoreErrors:
+    - '#Access to protected property Sample\\SampleResponsePayload::\$sampleAbout\.#'
+    - '#Access to protected property Sample\\SampleResponsePayload::\$noGetterTestValue\.#'
+    - '#Access to an undefined property Sample\\SampleResponsePayload::\$noProperty\.#'

--- a/src/Payload/AbstractResponsePayload.php
+++ b/src/Payload/AbstractResponsePayload.php
@@ -3,6 +3,9 @@ declare(strict_types=1);
 
 namespace Shampine\Sequence\Payload;
 
+use Shampine\Sequence\Response\GetterTrait;
+
 abstract class AbstractResponsePayload
 {
+    use GetterTrait;
 }

--- a/src/Pipeline/AbstractPipeline.php
+++ b/src/Pipeline/AbstractPipeline.php
@@ -96,7 +96,7 @@ abstract class AbstractPipeline
             $propertyName = $property->name;
             $snakeCasePropertyName = Str::snakeCase($propertyName);
             $transformKey = ($useSnakeCase) ? $snakeCasePropertyName : $propertyName;
-            $propertyValue = $class->{Str::getter($propertyName)}();
+            $propertyValue = $class->{$propertyName};
 
             if (in_array($snakeCasePropertyName, $this->excludeWhenEmpty) && empty($propertyValue)) {
                 continue;

--- a/src/Response/GetterTrait.php
+++ b/src/Response/GetterTrait.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace Shampine\Sequence\Response;
+
+use Shampine\Sequence\Support\Str;
+
+trait GetterTrait
+{
+    /**
+     * @param string $property
+     * @return mixed|null
+     */
+    public function __get(string $property)
+    {
+        $getter = Str::getter($property);
+
+        if (method_exists($this, $getter)) {
+            return $this->{$getter}();
+        }
+
+        if (property_exists($this, $property)) {
+            return $this->{$property};
+        }
+
+        return null;
+    }
+}

--- a/src/Response/SuccessResponse.php
+++ b/src/Response/SuccessResponse.php
@@ -7,6 +7,8 @@ use Shampine\Sequence\Support\StatusCode;
 
 class SuccessResponse
 {
+    use GetterTrait;
+
     /**
      * @var int|null $errorCode
      */

--- a/tests/Response/GetterTest.php
+++ b/tests/Response/GetterTest.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace Response;
+
+use PHPUnit\Framework\TestCase;
+use Sample\SampleRequestPayload;
+use Sample\SampleResponsePayload;
+
+class GetterTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function testGetter(): void
+    {
+        $payload = new SampleRequestPayload();
+        $payload->setAge(21);
+        $payload->setName('Maxwell');
+        $response = new SampleResponsePayload($payload);
+
+        echo $response->getSampleAbout();
+
+        $this->assertEquals('Maxwell is 21 years old.', $response->sampleAbout);
+        $this->assertEquals('noGetterTestValue', $response->noGetterTestValue);
+        $this->assertNull($response->noProperty);
+    }
+}

--- a/tests/Sample/SampleResponsePayload.php
+++ b/tests/Sample/SampleResponsePayload.php
@@ -23,6 +23,11 @@ class SampleResponsePayload extends AbstractResponsePayload
     protected ?string $nullValue = null;
 
     /**
+     * @var string|null
+     */
+    protected ?string $noGetterTestValue = 'noGetterTestValue';
+
+    /**
      * @param SampleRequestPayload $payload
      */
     public function __construct(SampleRequestPayload $payload)


### PR DESCRIPTION
If you call the protected properties directly on Response classes they will auto check if a getter exists else access the property directly.

This will allow response classes without any getters.